### PR TITLE
Enables repo to be able to write reports using parallel_rspec

### DIFF
--- a/lib/rspec_html_reporter.rb
+++ b/lib/rspec_html_reporter.rb
@@ -165,6 +165,9 @@ class RspecHtmlReporter < RSpec::Core::Formatters::BaseFormatter
   SCREENSHOT_DIR   = File.join(REPORT_PATH, 'screenshots')
   RESOURCE_DIR     = File.join(REPORT_PATH, 'resources')
   JSON_DIR         = File.join(REPORT_PATH, 'json')
+
+  # `ENV['TEST_ENV_NUMBER']` comes from parallel_rspec.  It also has a bug where the first parallel
+  # process is rendered as a "".  Also when run synchronously it's nil. So this handles that
   TEST_NUMBER      = ENV['TEST_ENV_NUMBER']&.empty? || ENV['TEST_ENV_NUMBER'].nil? ? '1' :
                      ENV['TEST_ENV_NUMBER']
 

--- a/lib/rspec_html_reporter.rb
+++ b/lib/rspec_html_reporter.rb
@@ -218,6 +218,9 @@ class RspecHtmlReporter < RSpec::Core::Formatters::BaseFormatter
   end
 
   def example_group_finished(notification)
+    # Don't save any content if we're rerunning but the RSpec flag isn't turned on
+    return if ENV['RE_RUN'] && !RSpec.configuration.only_failures?
+
     @group_level -= 1
     if @group_level == 0
       file_name = notification.group.metadata[:location]
@@ -264,6 +267,9 @@ class RspecHtmlReporter < RSpec::Core::Formatters::BaseFormatter
   end
 
   def close(notification)
+    # Don't save any content if we're rerunning but the RSpec flag isn't turned on
+    return if ENV['RE_RUN'] && !RSpec.configuration.only_failures?
+
     # Always write `@all_groups` to json file.  That's how reporting works in parallel
     File.write("#{JSON_DIR}/#{TEST_NUMBER}.json", @all_groups.to_json)
 

--- a/lib/rspec_html_reporter.rb
+++ b/lib/rspec_html_reporter.rb
@@ -219,9 +219,12 @@ class RspecHtmlReporter < RSpec::Core::Formatters::BaseFormatter
 
   def example_group_finished(notification)
     @group_level -= 1
-
     if @group_level == 0
-      File.open("#{REPORT_PATH}/#{notification.group.description.parameterize}.html", 'w') do |f|
+      file_name = notification.group.metadata[:location]
+                                      .gsub('./','')
+                                      .gsub('/','-')
+                                      .gsub(/\.rb\:\d+/,'')
+      File.open("#{REPORT_PATH}/#{file_name}.html", 'w') do |f|
 
         @passed = @group_example_success_count
         @failed = @group_example_failure_count
@@ -244,7 +247,7 @@ class RspecHtmlReporter < RSpec::Core::Formatters::BaseFormatter
         class_map = {passed: 'success', failed: 'danger', pending: 'warning'}
         statuses = @examples.map { |e| e.status }
         status = statuses.include?('failed') ? 'failed' : (statuses.include?('passed') ? 'passed' : 'pending')
-        @all_groups[notification.group.description.parameterize] = {
+        @all_groups[file_name] = {
             group: notification.group.description,
             examples: @examples.size,
             status: status,

--- a/templates/overview.erb
+++ b/templates/overview.erb
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Rspec HTML Reports - Overview</title>
+  <title>Rspec HTML Reports - <%= @name_of_report %></title>
 
   <!-- Bootstrap -->
   <link href="resources/bootstrap-4.0.0-dist/css/bootstrap.min.css" rel="stylesheet">
@@ -41,7 +41,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
               </button>
-              <p class="text-center" style="font-size:2em;">Overview</p>
+              <p class="text-center" style="font-size:2em;"><%= @name_of_report %></p>
             </div>
           </div>
         </div>

--- a/templates/overview.erb
+++ b/templates/overview.erb
@@ -23,7 +23,6 @@
       * {
           font-size: 14px;
       }
-
       <%= Rouge::Themes::Github.render(:scope => '.highlight') %>
   </style>
 </head>
@@ -86,13 +85,13 @@
             <tr>
               <td><%= i %></td>
               <td>
-                <a href="<%= group_name %>.html"><%= group[:group] %></a>
+                <a href="<%= group_name %>.html"><%= group['group'] %></a>
               </td>
               <td><%= group[:duration] %></td>
-              <td class="warning"><span><%= group[:pending].size %></span></td>
-              <td class="danger"><span><%= group[:failed].size %></span></td>
-              <td class="success"><span><%= group[:passed].size %></span></td>
-              <td><span class="label label-<%= group[:klass]%>"><%= group[:status] %></span></td>
+              <td class="warning"><span><%= group['pending'].size %></span></td>
+              <td class="danger"><span><%= group['failed'].size %></span></td>
+              <td class="success"><span><%= group['passed'].size %></span></td>
+              <td><span class="label label-<%= group['klass']%>"><%= group['status'] %></span></td>
             </tr>
         <% i+= 1%>
         <% end %>
@@ -105,9 +104,7 @@
 </div>
 
 <script type="text/javascript">
-
   var pieCtx = document.getElementById("pieChart");
-
   var pieChart = new Chart(pieCtx, {
     type: 'doughnut',
     data: {
@@ -115,7 +112,6 @@
         datasets: [{
           label: 'Examples',
           data: [<%= @passed %>, <%= @failed %>, <%= @pending %>],
-
           backgroundColor: [
             '#3c9a5f',
             '#ea2f10',
@@ -130,7 +126,6 @@
         }]
     },
   });
-
 </script>
 
 </body>

--- a/templates/report.erb
+++ b/templates/report.erb
@@ -23,7 +23,6 @@
       * {
           font-size: 14px;
       }
-
       .spacer {
         margin-left: 10px;
       }
@@ -155,8 +154,10 @@
                         </div>
                         <div class="panel-body">
                           <%= example.exception.explanation %>
-                          <h5><%= example.exception.backtrace_message %></h5>
                           <%= example.exception.highlighted_source %>
+                          <% example.exception.backtrace.each_with_index do |exception, i| %>
+                            <% if i <=15 %><h5><%= exception%></h5><% end %>
+                          <% end %>
                         </div>
 
                           <% if example.has_failed_screenshot? %>
@@ -189,7 +190,6 @@
 
 <script type="text/javascript">
   var pieCtx = document.getElementById("pieChart");
-
   var pieChart = new Chart(pieCtx, {
     type: 'doughnut',
     data: {
@@ -197,7 +197,6 @@
       datasets: [{
         label: 'Examples',
         data: [<%= @passed %>, <%= @failed %>, <%= @pending %>],
-
         backgroundColor: [
           '#3c9a5f',
           '#ea2f10',
@@ -212,7 +211,6 @@
       }]
     },
   });
-
   function toggler(divId) {
     $("#" + divId).slideToggle();
   }


### PR DESCRIPTION
### Why are we forking this repo?!?
Hey ReviewTrackers.  Welcome a fork of https://github.com/vbanthia/rspec_html_reporter into the RT codebase! Why did I fork this package, you may ask?

Well, this repo wasn't designed to write reports in parallel, but upon reading through it's code, I realized I could easily achieve this -- with a few tweaks. 

Also, this is simply a reporting repository.  It's nothing mission critical. But it will improve our quality of life! I thought it would be worthwhile to modify, as opposed to reinventing the wheel on our own repo.  None of the other reporting repos are great, anyways.  This one's pretty sweet!

### Overview of changes
I made comments where the important changes were with the original code. But at a high level:
* Changed the setup code so directories that are already created don't overwrite each other or error out, when run in parallel
* Designed the directory structure so that we can run reports multiple times in the same repo/container, and the different reports won't overwrite each other.  
  * That's due to the variable `ENV['RUNNING_TESTS']` 
* Saved a particular important variable for reporting to json across runs, and then recombine it with all the results across runs, to create a proper `overview.html` report!
* Tweaked the `reports.erb` file to report 15 lines of backtrace, not just 1.  **This is editable, so if you want more or less, let me know**
* Tweaked `rspec_html_reporter.rb` and `overview.erb` to not use symbols, since converting from ruby --> json --> ruby converts symbols to strings
* Tweaked `RSpecHtmlReporter#close` (which creates the overview.html file) to 
  * Filter fails to the top of the report
  * Instead of the header being 'Overview', its now the `ENV['RUNNING_TESTS']` 


